### PR TITLE
Add new config options for rpi IR in bootcfg.txt

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -186,9 +186,22 @@ serial_ir_device: ttyS0
 # Pin for the GPIO remote receiver
 # rpi_ir_gpio_pin: 24
 
+# Other example for the GPIO remote receiver that enables the pullup
+# rpi_ir_gpio_pin: '22,gpio_in_pull=up'
+
 # Pin for the GPIO remote sender (needs additional lirc configuration,
 # which is at the moment beyond the scope of this playbook)
-# rpi_ir_gpio_pin_tx: 13
+# rpi_ir_gpio_pin_tx: '18'
+
+# Alternative IR remote sender example using the PWM 
+# rpi_ir_pwm_pin_tx: '18'
+
+# Add arbitrary lines to usercfg.txt
+# rpi_user_config_line:
+#   - '# A line'
+#   - '# Another line'
+#   - '# even more line'
+
 
 # Set the memory for the GPU core - rpihddevice needs 256 MB, which is the default value set by the playbook
 # rpi_gpu_mem = 256

--- a/roles/rpi/templates/usercfg.txt.j2
+++ b/roles/rpi/templates/usercfg.txt.j2
@@ -12,5 +12,14 @@ decode_WVC1={{ rpi_decode_wvc1 }}
 dtoverlay=gpio-ir,gpio_pin={{ rpi_ir_gpio_pin }}
 {% endif %}
 {% if rpi_ir_gpio_pin_tx is defined %}
-dtoverlay=gpio-ir-recv-tx,gpio_pin={{ rpi_ir_gpio_pin_tx }}
+dtoverlay=gpio-ir-tx,gpio_pin={{ rpi_ir_gpio_pin_tx }}
+{% endif %}
+{% if rpi_ir_pwm_pin_tx is defined %}
+dtoverlay=pwm-ir-tx,gpio_pin={{ rpi_ir_pwm_pin_tx }}
+{% endif %}
+{# Allow for arbitrary entries #}
+{% if rpi_user_config_line is defined %}
+{% for item in rpi_user_config_line %}
+{{ item }}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
Hi Seahawk,
as promised in the portal here comes the pull-request that adds the pwm sender for IR.
Also added a way to add arbitrary lines to the usercfg.txt.
And examples to groupvar/all.

PS:
My first pull-request with github. In the job I use Bitbucket and Gitkraken.
And let me thank you for bringing me into the world of Ansible. I learned about it as I saw yavdr-ansible and wondered what the hell is Ansible. Meanwhile I use it a lot.

A much better way compared to the old yavdr ISO files.

Thanks, Dieter Fauth