### PR TITLE
Update 50_custom.j2

### DIFF
--- a/roles/grub-config/templates/50_custom.j2
+++ b/roles/grub-config/templates/50_custom.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 {{ ansible_managed | comment }}
 
 exec tail -n +3 $0


### PR DESCRIPTION
Bei `/usr/bin/sh` gibt es bei einem manuellen `update-grub` einen Fehler; mit `/bin/sh` arbeitet `update-grub` korrekt.