### PR TITLE
Add a config file to set the recordings directory

### DIFF
--- a/roles/vdr/tasks/main.yml
+++ b/roles/vdr/tasks/main.yml
@@ -27,13 +27,18 @@
 
 - name: set vdr charset override
   template:
-    src: templates/conf.d/02-vdr-charset-override.conf.j2
+    src: conf.d/02-vdr-charset-override.conf.j2
     dest: /etc/vdr/conf.d/02-vdr-charset-override.conf
 
 - name: set option to use hide-first-recording-level patch
   template:
-    src: templates/conf.d/04-vdr-hide-first-recordinglevel.conf.j2
+    src: conf.d/04-vdr-hide-first-recordinglevel.conf.j2
     dest: /etc/vdr/conf.d/04-vdr-hide-first-recordinglevel.conf
+
+- name: set option to define recordings directory
+  template:
+    src: conf.d/06-vdr-recordings.conf.j2
+    dest: /etc/vdr/conf.d/06-vdr-recordings.conf
 
 - name: create local dir in recdir
   file:

--- a/roles/vdr/templates/conf.d/06-vdr-recordings.conf.j2
+++ b/roles/vdr/templates/conf.d/06-vdr-recordings.conf.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+
+[vdr]
+--video={{ vdr.recdir }}


### PR DESCRIPTION
Even when changing vdr.recdir vdr wasn't using the modified value.

Oh, and the templates/ directory isn't necessary, Ansible knows where to search for templates.