### PR TITLE
Make it easier to configure remotely one (or more) YAVDR host

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,5 +1,9 @@
 ---
 # file: group_vars/all
+# Ansible configuration, overwrite if you want to use the playbook(s) remotely
+# e.g. in a file `host_vars/my_yavdr_host`
+ansible_host: localhost
+ansible_connection: local
 
 branch: experimental
 ppa_owner: 'ppa:yavdr'

--- a/hosts
+++ b/hosts
@@ -1,8 +1,5 @@
 [yavdr_full]
-localhost ansible_host=localhost ansible_connection=local
-
-[yavdr_full:vars]
-ansible_python_interpreter=/root/.ansible-env/bin/python3[yavdr_full]
+my_yavdr_host
 
 [yavdr_headless]
 

--- a/remote-yavdr.sh
+++ b/remote-yavdr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# use this script to configure a remote VDR host instead of localhost
+set -e
+
+ansible-playbook yavdr07.yml -i 'hosts' --ask-become-pass "$@"

--- a/yavdr07.yml
+++ b/yavdr07.yml
@@ -7,6 +7,15 @@
   become: true
   environment:
     LANG: "{{ default_locale | default('c.UTF-8') }}"
+
+  pre_tasks:
+    - name: update all packages if the action doesn't happen locally
+      apt:
+        name: "*"
+        state: latest
+        update_cache: true
+      when: (ansible_host | default(inventory_hostname)) not in ['localhost', '127.0.0.1']
+
   roles:
     - yavdr-common               # install and configure the basic system
     - collect-facts              # query system facts


### PR DESCRIPTION
- add a remote-yavdr.sh script to configure a remote YAVDR host
- adapt the inventory and group_vars to make it possible
- add an apt update/upgrade task to replace the local install-packages.sh

It makes it easier to develop as I have already most dependencies (ansible, SSH key, ...) on my laptop and don't want them on my YAVDR host. It also helps to reproduce a working setup on a new VDR host.