### PR TITLE
Fix name of stm32(irmp)-wakeup addon package

### DIFF
--- a/roles/wakeup/vars/main.yml
+++ b/roles/wakeup/vars/main.yml
@@ -3,7 +3,7 @@
 # name of add-on package(s) to install (it can be made a list of packages)
 wakeup_addon_packages:
   acpiwakeup: vdr-addon-acpiwakeup
-  stm32wakeup: vdr-addon-stmp32-wakeup
+  stm32wakeup: vdr-addon-stm32irmp-wakeup
 
 # path to configuration file, corresponding template is called like the
 # file's basename with .j2


### PR DESCRIPTION
As per https://www.vdr-portal.de/forum/index.php?thread/134949-yavdr-ansible-stm32-implementierung-fehlerhaft/