### PR TITLE
Update reccmds with generic shebang

### DIFF
--- a/roles/vdr/files/reccmds/removeindex.sh
+++ b/roles/vdr/files/reccmds/removeindex.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 find "$1" -maxdepth 1 \( -name "index" -o -name "index.vdr" \) -delete

--- a/roles/vdr/files/reccmds/removemarks.sh
+++ b/roles/vdr/files/reccmds/removemarks.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 find "$1" -maxdepth 1 \( -name "marks" -o -name "marks.vdr" \) -delete

--- a/roles/vdr/files/reccmds/removeresume.sh
+++ b/roles/vdr/files/reccmds/removeresume.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 find "$1" -maxdepth 1 -type f \( -name "resume" -o -name "resume.*" \) -delete

--- a/roles/vdr/files/reccmds/vdr-recrepeat.sh
+++ b/roles/vdr/files/reccmds/vdr-recrepeat.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 #------------------------------------------------------------------------------
 # this script allows searching for a repeat of a recording using epgsearch
 # add the following lines to your reccmds.conf


### PR DESCRIPTION
The reccmds scripts are updated with a more generic shebang to make them work on Ubuntu 20.04.