### PR TITLE
Update include-edid-data.sh.j2 with generic shebang

### DIFF
--- a/roles/yavdr-xorg/templates/include-edid-data.sh.j2
+++ b/roles/yavdr-xorg/templates/include-edid-data.sh.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 {{ ansible_managed | comment }}
 # This hook copies EDID files with the naming scheme "edid.${OUTPUT}.bin" to the initramfs.
 


### PR DESCRIPTION
The template fails to work if interpreter not set properly.